### PR TITLE
Fix #521: provide longitude before latitude when calling query.lonlat_box

### DIFF
--- a/docs/sphinx/source/whatsnew/v0.6.0.rst
+++ b/docs/sphinx/source/whatsnew/v0.6.0.rst
@@ -67,6 +67,7 @@ Bug fixes
   floats and NumPy arrays. (:issue:`508`)
 * Make GitHub recognize the license, add AUTHORS.md, clarify shared copyright.
   (:issue:`503`)
+* Fix argument order of longitude and latitude when querying weather forecasts by lonlat bounding box (:issue:`521`)
 
 
 Documentation

--- a/pvlib/forecast.py
+++ b/pvlib/forecast.py
@@ -174,8 +174,8 @@ class ForecastModel(object):
                 isinstance(self.latitude, list)):
             self.lbox = True
             # west, east, south, north
-            self.query.lonlat_box(self.latitude[0], self.latitude[1],
-                                  self.longitude[0], self.longitude[1])
+            self.query.lonlat_box(self.longitude[0], self.longitude[1],
+                                  self.latitude[0], self.latitude[1])
         else:
             self.lbox = False
             self.query.lonlat_point(self.longitude, self.latitude)


### PR DESCRIPTION
See signature of `siphon.DataQuery.lonlat_box`: https://github.com/Unidata/siphon/blob/a6529fbaf3165f93cdffa87080295431a647df2c/siphon/http_util.py#L174

pvlib python pull request guidelines
====================================

Thank you for your contribution to pvlib python! You may delete all of these instructions except for the list below.

You may submit a pull request with your code at any stage of completion.

The following items must be addressed before the code can be merged. Please don't hesitate to ask for help if you're unsure of how to accomplish any of the items below:

 - [x] Closes issue #521
 - [x] I am familiar with the [contributing guidelines](http://pvlib-python.readthedocs.io/en/latest/contributing.html).
 - [ ] Fully tested. Added and/or modified tests to ensure correct behavior for all reasonable inputs. Tests (usually) must pass on the TravisCI and Appveyor testing services.
 - N/A Updates entries to `docs/sphinx/source/api.rst` for API changes.
 - [x] Adds description and name entries in the appropriate `docs/sphinx/source/whatsnew` file for all changes.
 - [x] Code quality and style is sufficient. Passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [x] New code is fully documented. Includes sphinx/numpydoc compliant docstrings and comments in the code where necessary.
 - [x] Pull request is nearly complete and ready for detailed review.
